### PR TITLE
Test PR for github actions

### DIFF
--- a/osbenchmark/benchmark.py
+++ b/osbenchmark/benchmark.py
@@ -893,7 +893,7 @@ def dispatch_sub_command(arg_parser, args, cfg):
             cfg.add(config.Scope.applicationOverride, "workload", "latency.percentiles", args.latency_percentiles)
             cfg.add(config.Scope.applicationOverride, "workload", "throughput.percentiles", args.throughput_percentiles)
             cfg.add(config.Scope.applicationOverride, "workload", "randomization.enabled", args.randomization_enabled)
-            cfg.add(config.Scope.applicationOverride, "workload", "randomization.rf", args.randomization_rf)
+            cfg.add(config.Scope.applicationOverride, "workload", "randomization.repeat_frequency", args.randomization_repeat_frequency)
             cfg.add(config.Scope.applicationOverride, "workload", "randomization.n", args.randomization_n)
             configure_workload_params(arg_parser, args, cfg)
             configure_connection_params(arg_parser, args, cfg)

--- a/osbenchmark/benchmark.py
+++ b/osbenchmark/benchmark.py
@@ -573,7 +573,7 @@ def create_arg_parser():
         action="store_true")
     test_execution_parser.add_argument(
         "--randomization-repeat-frequency",
-        "--randomization-rf",
+        "-rf",
         help=f"The repeat_frequency for query randomization. Ignored if randomization is off"
              f"(default: {workload.loader.QueryRandomizerWorkloadProcessor.DEFAULT_RF}).",
         default=workload.loader.QueryRandomizerWorkloadProcessor.DEFAULT_RF)

--- a/osbenchmark/benchmark.py
+++ b/osbenchmark/benchmark.py
@@ -573,11 +573,13 @@ def create_arg_parser():
         action="store_true")
     test_execution_parser.add_argument(
         "--randomization-rf",
-        help="The repeat_frequency for query randomization. Ignored if randomization is off (default: {workload.loader.QueryRandomizerWorkloadProcessor.DEFAULT_RF}).",
+        help=f"The repeat_frequency for query randomization. Ignored if randomization is off"
+             f"(default: {workload.loader.QueryRandomizerWorkloadProcessor.DEFAULT_RF}).",
         default=workload.loader.QueryRandomizerWorkloadProcessor.DEFAULT_RF)
     test_execution_parser.add_argument(
         "--randomization-n",
-        help="The number of standard values to generate for each field for query randomization. Ignored if randomization is off (default: {workload.loader.QueryRandomizerWorkloadProcessor.DEFAULT_N}).",
+        help=f"The number of standard values to generate for each field for query randomization."
+             f"Ignored if randomization is off (default: {workload.loader.QueryRandomizerWorkloadProcessor.DEFAULT_N}).",
         default=workload.loader.QueryRandomizerWorkloadProcessor.DEFAULT_N)
 
     ###############################################################################
@@ -887,14 +889,11 @@ def dispatch_sub_command(arg_parser, args, cfg):
                 "load_worker_coordinator_hosts",
                 opts.csv_to_list(args.load_worker_coordinator_hosts))
             cfg.add(config.Scope.applicationOverride, "workload", "test.mode.enabled", args.test_mode)
-<<<<<<< HEAD
             cfg.add(config.Scope.applicationOverride, "workload", "latency.percentiles", args.latency_percentiles)
             cfg.add(config.Scope.applicationOverride, "workload", "throughput.percentiles", args.throughput_percentiles)
-=======
             cfg.add(config.Scope.applicationOverride, "workload", "randomization.enabled", args.randomization_enabled)
             cfg.add(config.Scope.applicationOverride, "workload", "randomization.rf", args.randomization_rf)
             cfg.add(config.Scope.applicationOverride, "workload", "randomization.n", args.randomization_n)
->>>>>>> randomized
             configure_workload_params(arg_parser, args, cfg)
             configure_connection_params(arg_parser, args, cfg)
             configure_telemetry_params(args, cfg)

--- a/osbenchmark/benchmark.py
+++ b/osbenchmark/benchmark.py
@@ -566,6 +566,19 @@ def create_arg_parser():
              f"(default: {metrics.GlobalStatsCalculator.DEFAULT_THROUGHPUT_PERCENTILES}).",
         default=metrics.GlobalStatsCalculator.DEFAULT_THROUGHPUT_PERCENTILES
     )
+    test_execution_parser.add_argument(
+        "--randomization-enabled",
+        help="Runs the given workload with query randomization enabled (default: false).",
+        default=False,
+        action="store_true")
+    test_execution_parser.add_argument(
+        "--randomization-rf",
+        help="The repeat_frequency for query randomization. Ignored if randomization is off (default: {workload.loader.QueryRandomizerWorkloadProcessor.DEFAULT_RF}).",
+        default=workload.loader.QueryRandomizerWorkloadProcessor.DEFAULT_RF)
+    test_execution_parser.add_argument(
+        "--randomization-n",
+        help="The number of standard values to generate for each field for query randomization. Ignored if randomization is off (default: {workload.loader.QueryRandomizerWorkloadProcessor.DEFAULT_N}).",
+        default=workload.loader.QueryRandomizerWorkloadProcessor.DEFAULT_N)
 
     ###############################################################################
     #
@@ -874,8 +887,14 @@ def dispatch_sub_command(arg_parser, args, cfg):
                 "load_worker_coordinator_hosts",
                 opts.csv_to_list(args.load_worker_coordinator_hosts))
             cfg.add(config.Scope.applicationOverride, "workload", "test.mode.enabled", args.test_mode)
+<<<<<<< HEAD
             cfg.add(config.Scope.applicationOverride, "workload", "latency.percentiles", args.latency_percentiles)
             cfg.add(config.Scope.applicationOverride, "workload", "throughput.percentiles", args.throughput_percentiles)
+=======
+            cfg.add(config.Scope.applicationOverride, "workload", "randomization.enabled", args.randomization_enabled)
+            cfg.add(config.Scope.applicationOverride, "workload", "randomization.rf", args.randomization_rf)
+            cfg.add(config.Scope.applicationOverride, "workload", "randomization.n", args.randomization_n)
+>>>>>>> randomized
             configure_workload_params(arg_parser, args, cfg)
             configure_connection_params(arg_parser, args, cfg)
             configure_telemetry_params(args, cfg)

--- a/osbenchmark/benchmark.py
+++ b/osbenchmark/benchmark.py
@@ -572,6 +572,7 @@ def create_arg_parser():
         default=False,
         action="store_true")
     test_execution_parser.add_argument(
+        "--randomization-repeat-frequency",
         "--randomization-rf",
         help=f"The repeat_frequency for query randomization. Ignored if randomization is off"
              f"(default: {workload.loader.QueryRandomizerWorkloadProcessor.DEFAULT_RF}).",

--- a/osbenchmark/workload/loader.py
+++ b/osbenchmark/workload/loader.py
@@ -25,6 +25,7 @@ import glob
 import json
 import logging
 import os
+import random
 import re
 import sys
 import tempfile
@@ -74,7 +75,7 @@ class WorkloadProcessor:
 
 class WorkloadProcessorRegistry:
     def __init__(self, cfg):
-        self.required_processors = [TaskFilterWorkloadProcessor(cfg), TestModeWorkloadProcessor(cfg)]
+        self.required_processors = [TaskFilterWorkloadProcessor(cfg), TestModeWorkloadProcessor(cfg), QueryRandomizerWorkloadProcessor(cfg)]
         self.workload_processors = []
         self.offline = cfg.opts("system", "offline.mode")
         self.test_mode = cfg.opts("workload", "test.mode.enabled", mandatory=False, default_value=False)
@@ -920,6 +921,177 @@ class TestModeWorkloadProcessor(WorkloadProcessor):
 
         return workload
 
+class QueryRandomizerWorkloadProcessor(WorkloadProcessor):
+    DEFAULT_RF = 0.3
+    DEFAULT_N = 5000
+    def __init__(self, cfg):
+        self.randomization_enabled = cfg.opts("workload", "randomization.enabled", mandatory=False, default_value=False)
+        self.rf = float(cfg.opts("workload", "randomization.rf", mandatory=False, default_value=self.DEFAULT_RF))
+        self.logger = logging.getLogger(__name__)
+        self.N = int(cfg.opts("workload", "randomization.n", mandatory=False, default_value=self.DEFAULT_N))
+        self.zipf_alpha = 1
+        self.H_list = self.precompute_H(self.N, self.zipf_alpha)
+
+    # Helper functions for computing Zipf distribution
+    def H(self, i, H_list):
+        # compute the harmonic number H_n,m = sum over i from 1 to n of (1 / i^m)
+        return H_list[i-1]
+
+    def precompute_H(self, n, m):
+        H_list = [1]
+        for j in range(2, n+1):
+            H_list.append(H_list[-1] + 1 / (j ** m))
+        return H_list
+
+    def zipf_cdf_inverse(self, u, H_list):
+        # To map a uniformly distributed u from [0, 1] to some probability distribution we plug it into its inverse CDF.
+        # as the zipf cdf is discontinuous there is no real inverse but we can use this solution:
+        # https://math.stackexchange.com/questions/53671/how-to-calculate-the-inverse-cdf-for-the-zipf-distribution
+        # Precompute all values H_i,alpha for a fixed alpha and pass in as H_list
+        if (u < 0 or u >= 1):
+            raise Exception("Input u must have 0 <= u < 1")
+        n = len(H_list)
+        candidate_return = 1
+        denominator = self.H(n, H_list)
+        numerator = 0
+        while candidate_return < n:
+            numerator = self.H(candidate_return, H_list)
+            if u < numerator / denominator:
+                return candidate_return
+            candidate_return += 1
+        return n
+
+    def get_dict_from_previous_path(self, root, current_path):
+        curr = root
+        for value in current_path:
+            curr = curr[value]
+        return curr
+
+    def extract_fields_helper(self, root, current_path):
+        # Recursively called to find the location of ranges in an OpenSearch range query.
+        # Return the field and the current path if we're currently scanning the field name in a range query, otherwise return an empty list.
+        fields = [] # pairs of (field, path_to_field)
+        curr = self.get_dict_from_previous_path(root, current_path)
+        if type(curr) is dict and curr != {}:
+            if len(current_path) > 0 and current_path[-1] == "range":
+                for key in curr.keys():
+                    if type(curr[key]) == dict:
+                        if ("gte" in curr[key] or "gt" in curr[key]) and ("lte" in curr[key] or "lt" in curr[key]):
+                            fields.append((key, current_path))
+                return fields
+            else:
+                for key in curr.keys():
+                    fields += self.extract_fields_helper(root, current_path + [key])
+                return fields
+        elif type(curr) is list and curr != []:
+            for i, value in enumerate(curr):
+                fields += self.extract_fields_helper(root, current_path + [i])
+            return fields
+        else:
+            # leaf node
+            return []
+
+    def extract_fields_and_paths(self, params):
+        # Search for fields used in range queries, and the paths to those fields
+        # Return pairs of (field, path_to_field)
+        # TODO: Maybe only do this the first time, and assume for a given task, the same query structure is used.
+        # We could achieve this by passing in the task name to get_randomized_values as a kwarg?
+        try:
+            root = params["body"]["query"]
+        except KeyError:
+            raise exceptions.SystemSetupError("Cannot extract range query fields from these params, missing params[\"body\"][\"query\"]")
+        fields_and_paths = self.extract_fields_helper(root, [])
+        return fields_and_paths
+
+    def set_range(self, params, fields_and_paths, new_values):
+        assert len(fields_and_paths) == len(new_values)
+        for field_and_path, new_value in zip(fields_and_paths, new_values):
+            field = field_and_path[0]
+            path = field_and_path[1]
+            range_section = self.get_dict_from_previous_path(params["body"]["query"], path)[field]
+            # get the section of the query corresponding to the field name
+            for greater_than in ["gte", "gt"]:
+                if greater_than in range_section:
+                    range_section[greater_than] = new_value["gte"]
+            for less_than in ["lte", "lt"]:
+                if less_than in range_section:
+                    range_section[less_than] = new_value["lte"]
+            if "format" in new_values:
+                range_section["format"] = new_values["format"]
+        return params
+
+    def get_repeated_value_index(self):
+        # minus 1 for mapping [1, N] to [0, N-1] of list indices
+        return self.zipf_cdf_inverse(random.random(), self.H_list) - 1
+
+    def get_randomized_values(self, input_workload, input_params,
+                              get_standard_value=params.get_standard_value,
+                              get_standard_value_source=params.get_standard_value_source, # Made these configurable for simpler unit tests
+                              **kwargs):
+
+        # The queries as listed in operations/default.json don't have the index param,
+        # unlike the custom ones you would specify in workload.py, so we have to add them ourselves
+        if not "index" in input_params:
+            input_params["index"] = params.get_target(input_workload, input_params)
+
+        fields_and_paths = self.extract_fields_and_paths(input_params)
+
+        if random.random() < self.rf:
+            # Draw a potentially repeated value from the saved standard values
+            index = self.get_repeated_value_index()
+            new_values = [get_standard_value(kwargs["op_name"], field_and_path[0], index) for field_and_path in fields_and_paths]
+            # Use the same index for all fields in one query, otherwise the probability of repeats in a multi-field query would be very low
+            input_params = self.set_range(input_params, fields_and_paths, new_values)
+        else:
+            # Generate a new random value, from the standard value source function. This will be new (a cache miss)
+            new_values = [get_standard_value_source(kwargs["op_name"], field_and_path[0])() for field_and_path in fields_and_paths]
+            input_params = self.set_range(input_params, fields_and_paths, new_values)
+        return input_params
+
+    def create_param_source_lambda(self, op_name, get_standard_value, get_standard_value_source):
+        return lambda w, p, **kwargs: self.get_randomized_values(w, p,
+                                                                 get_standard_value=get_standard_value,
+                                                                 get_standard_value_source=get_standard_value_source,
+                                                                 op_name=op_name, **kwargs)
+
+    def on_after_load_workload(self, input_workload,
+                               get_standard_value=None,
+                               get_standard_value_source=None):
+
+        if not self.randomization_enabled:
+            return input_workload
+
+        # By default, use params for standard values and generate new standard values the first time an op/field is seen.
+        # In unit tests, we should be able to supply our own sources independent of params.
+        generate_new_standard_values = False
+        if get_standard_value is None:
+            get_standard_value = params.get_standard_value
+            generate_new_standard_values = True
+        if get_standard_value_source is None:
+            get_standard_value_source = params.get_standard_value_source
+            generate_new_standard_values = True
+
+        for test_procedure in input_workload.test_procedures:
+            if test_procedure.default: # TODO - not sure if this is correct
+                for task in test_procedure.schedule:
+                    for leaf_task in task:
+                        try:
+                            op_type = workload.OperationType.from_hyphenated_string(leaf_task.operation.type)
+                        except KeyError:
+                            op_type = None
+                        if op_type == workload.OperationType.Search:
+                            op_name = leaf_task.operation.name
+                            param_source_name = op_name + "-randomized"
+                            params.register_param_source_for_name(
+                                param_source_name,
+                                self.create_param_source_lambda(op_name, get_standard_value=get_standard_value,
+                                                                get_standard_value_source=get_standard_value_source))
+                            leaf_task.operation.param_source = param_source_name
+                            # Generate the right number of standard values for this field, if not already present
+                            for field_and_path in self.extract_fields_and_paths(leaf_task.operation.params):
+                                if generate_new_standard_values:
+                                    params.generate_standard_values_if_absent(op_name, field_and_path[0], self.N)
+        return input_workload
 
 class CompleteWorkloadParams:
     def __init__(self, user_specified_workload_params=None):
@@ -1096,6 +1268,10 @@ class WorkloadPluginReader:
     def register_workload_processor(self, workload_processor):
         if self.workload_processor_registry:
             self.workload_processor_registry(workload_processor)
+
+    def register_standard_value_source(self, op_name, field_name, standard_value_source):
+        # Define a value source for parameters for a given operation name and field name, for use in randomization
+        params.register_standard_value_source(op_name, field_name, standard_value_source)
 
     @property
     def meta_data(self):

--- a/osbenchmark/workload/loader.py
+++ b/osbenchmark/workload/loader.py
@@ -1061,7 +1061,7 @@ class QueryRandomizerWorkloadProcessor(WorkloadProcessor):
         if not self.randomization_enabled:
             self.logger.info("Query randomization is disabled.")
             return input_workload
-        self.logger.info("Query randomization is enabled, with repeat frequency = {}, n = {}".format(self.rf, self.N))
+        self.logger.info("Query randomization is enabled, with repeat frequency = %d, n = %d",self.rf, self.N)
 
         # By default, use params for standard values and generate new standard values the first time an op/field is seen.
         # In unit tests, we should be able to supply our own sources independent of params.
@@ -1086,9 +1086,9 @@ class QueryRandomizerWorkloadProcessor(WorkloadProcessor):
                     op_type = workload.OperationType.from_hyphenated_string(leaf_task.operation.type)
                 except KeyError:
                     op_type = None
-                    self.logger.warn(
-                        f"QueryRandomizerWorkloadProcessor found operation {leaf_task.operation.name} in default schedule"
-                        f" with type {leaf_task.operation.type}, which couldn't be converted to a known OperationType")
+                    self.logger.info(
+                        "Found operation %s in default schedule with type %s, which couldn't be converted to a known OperationType",
+                        leaf_task.operation.name, leaf_task.operation.type)
                 if op_type == workload.OperationType.Search:
                     op_name = leaf_task.operation.name
                     param_source_name = op_name + "-randomized"

--- a/osbenchmark/workload/params.py
+++ b/osbenchmark/workload/params.py
@@ -69,7 +69,9 @@ def get_standard_value_source(op_name, field_name):
     try:
         return __STANDARD_VALUE_SOURCES[op_name][field_name]
     except KeyError:
-        raise exceptions.SystemSetupError("Could not find standard value source for operation {}, field {}! Make sure this is registered in workload.py".format(op_name, field_name))
+        raise exceptions.SystemSetupError(
+            "Could not find standard value source for operation {}, field {}! Make sure this is registered in workload.py"
+            .format(op_name, field_name))
 
 
 def ensure_valid_param_source(param_source):
@@ -103,8 +105,10 @@ def generate_standard_values_if_absent(op_name, field_name, n):
         try:
             standard_value_source = __STANDARD_VALUE_SOURCES[op_name][field_name]
         except KeyError:
-            raise exceptions.SystemSetupError("Cannot generate standard values for operation {}, field {}. Standard value source is missing".format(op_name, field_name))
-        for i in range(n):
+            raise exceptions.SystemSetupError(
+                "Cannot generate standard values for operation {}, field {}. Standard value source is missing"
+                .format(op_name, field_name))
+        for _i in range(n):
             __STANDARD_VALUES[op_name][field_name].append(standard_value_source())
 
 def get_standard_value(op_name, field_name, i):
@@ -113,7 +117,9 @@ def get_standard_value(op_name, field_name, i):
     except KeyError:
         raise exceptions.SystemSetupError("No standard values generated for operation {}, field {}".format(op_name, field_name))
     except IndexError:
-        raise exceptions.SystemSetupError("Standard value index {} out of range for operation {}, field name {} ({} values total)".format(i, op_name, field_name, len(__STANDARD_VALUES[op_name][field_name])))
+        raise exceptions.SystemSetupError(
+            "Standard value index {} out of range for operation {}, field name {} ({} values total)"
+            .format(i, op_name, field_name, len(__STANDARD_VALUES[op_name][field_name])))
 
 
 # only intended for tests

--- a/osbenchmark/workload/params.py
+++ b/osbenchmark/workload/params.py
@@ -88,8 +88,6 @@ def register_param_source_for_name(name, param_source_class):
     ensure_valid_param_source(param_source_class)
     __PARAM_SOURCES_BY_NAME[name] = param_source_class
 
-# These may not belong in params.py - they're here for now by analogy with register_param_source
-
 def register_standard_value_source(op_name, field_name, standard_value_source):
     if op_name in __STANDARD_VALUE_SOURCES:
         __STANDARD_VALUE_SOURCES[op_name][field_name] = standard_value_source

--- a/tests/workload/loader_test.py
+++ b/tests/workload/loader_test.py
@@ -1682,6 +1682,295 @@ class WorkloadFilterTests(TestCase):
         schedule = filtered.test_procedures[0].schedule
         self.assertEqual(expected_schedule, schedule)
 
+class WorkloadRandomizationTests(TestCase):
+
+    # Helper class used to set up queries with mock standard values for testing
+    # We want >1 op to ensure logic for giving different ops their own lambdas is working properly
+    class StandardValueHelper:
+        def __init__(self):
+            self.op_name_1 = "op-name-1"
+            self.op_name_2 = "op-name-2"
+            self.field_name_1 = "dummy_field_1"
+            self.field_name_2 = "dummy_field_2"
+            self.index_name = "dummy_index"
+
+            # Make the saved standard values different from the functions generating the new values,
+            # to be able to distinguish when we generate a new value vs draw an "existing" one.
+            # in actual usage, these would come from the same function with some randomness in it
+            self.saved_values = {
+                self.op_name_1:{
+                    self.field_name_1:{"lte":40, "gte":30},
+                    self.field_name_2:{"lte":"06/06/2016", "gte":"05/05/2016", "format":"dd/MM/yyyy"}
+                },
+                self.op_name_2:{
+                    self.field_name_1:{"lte":11, "gte":10}
+                }
+            }
+
+            # Used to generate new values, in the source function
+            self.new_values = {
+                self.op_name_1:{
+                    self.field_name_1:{"lte":41, "gte":31},
+                    self.field_name_2:{"lte":"04/04/2016", "gte":"03/03/2016", "format":"dd/MM/yyyy"}
+                },
+                self.op_name_2:{
+                    self.field_name_1:{"lte":15, "gte":14},
+                }
+            }
+
+            self.op_1_query = {
+                "name": self.op_name_1,
+                "operation-type": "search",
+                "body": {
+                    "size": 0,
+                    "query": {
+                        "bool": {
+                            "filter": {
+                                "range": {
+                                    self.field_name_1: {
+                                        "lt": 50,
+                                        "gte": 0
+                                    }
+                                },
+                                "must": [
+                                    {
+                                        "range": {
+                                            self.field_name_2: {
+                                                "gte": "01/01/2015",
+                                                "lte": "21/01/2015",
+                                                "format": "dd/MM/yyyy"
+                                            }
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    }
+                }
+            }
+
+            self.op_2_query = {
+                "name": self.op_name_2,
+                "operation-type": "search",
+                "body": {
+                    "size": 0,
+                    "query": {
+                        "range": {
+                            self.field_name_1: {
+                                "lt": 50,
+                                "gte": 0
+                            }
+                        }
+                    }
+                }
+            }
+
+        def get_simple_workload(self):
+            # Modified from test_filters_tasks
+            workload_specification = {
+                "description": "description for unit test",
+                "indices": [{"name": self.index_name, "auto-managed": False}],
+                "operations": [
+                    {
+                        "name": "create-index",
+                        "operation-type": "create-index"
+                    },
+                    self.op_1_query,
+                    self.op_2_query
+                ],
+                "test_procedures": [
+                    {
+                        "name": "default-test_procedure",
+                        "schedule": [
+                            {
+                                "operation": "create-index"
+                            },
+                            {
+                                "name": "dummy-task-name-1",
+                                "operation": self.op_name_1,
+                            },
+                            {
+                                "name": "dummy-task-name-2",
+                                "operation": self.op_name_2,
+                            },
+                        ]
+                    }
+                ]
+            }
+            reader = loader.WorkloadSpecificationReader()
+            full_workload = reader("unittest", workload_specification, "/mappings")
+            return full_workload
+
+        def get_standard_value_source(self, op_name, field_name): # Passed to the processor, to be able to find the standard value sources for all ops/fields.
+            # The actual source functions for the op/field pairs, which in a real application
+            # would be defined in the workload's workload.py and involve some randomization
+            return lambda: self.new_values[op_name][field_name]
+
+        def get_standard_value(self, op_name, field_name, index): # Passed to the processor, to be able to retrive the saved standard values for all ops/fields.
+            return self.saved_values[op_name][field_name]
+
+    def test_range_finding_function(self):
+        cfg = config.Config()
+        processor = loader.QueryRandomizerWorkloadProcessor(cfg)
+        single_range_query = {
+            "name": "distance_amount_agg",
+            "operation-type": "search",
+            "body": {
+                "size": 0,
+                "query": {
+                "bool": {
+                    "filter": {
+                    "range": {
+                        "trip_distance": {
+                        "lt": 50,
+                        "gte": 0
+                        }
+                    }
+                    }
+                }
+                }
+            }
+        }
+        single_range_query_result = processor.extract_fields_and_paths(single_range_query)
+        single_range_query_expected = [("trip_distance", ["bool", "filter", "range"])]
+        self.assertEqual(single_range_query_result, single_range_query_expected)
+
+        multiple_nested_range_query = {
+            "name": "date_histogram_agg",
+            "operation-type": "search",
+            "body": {
+                "size": 0,
+                "query": {
+                    "range": {
+                        "dropoff_datetime": {
+                            "gte": "01/01/2015",
+                            "lte": "21/01/2015",
+                            "format": "dd/MM/yyyy"
+                        }
+                },
+                "bool": {
+                    "filter": {
+                        "range": {
+                            "dummy_field": {
+                                "lte": 50,
+                                "gt": 0
+                            }
+                        }
+                    },
+                    "must": [
+                        {
+                            "range": {
+                                "dummy_field_2": {
+                                    "gte": "1998-05-01T00:00:00Z",
+                                    "lt": "1998-05-02T00:00:00Z"
+                                }
+                            }
+                        },
+                        {
+                            "match": {
+                            "status": "400"
+                            }
+                        },
+                        {
+                            "range": {
+                                "dummy_field_3": {
+                                    "gt": 10,
+                                    "lt": 11
+                                }
+                            }
+                        }
+                    ]
+                }
+                }
+            }
+        }
+        multiple_nested_range_query_result = processor.extract_fields_and_paths(multiple_nested_range_query)
+        print("Multi result: ", multiple_nested_range_query_result)
+        multiple_nested_range_query_expected = [
+            ("dropoff_datetime", ["range"]),
+            ("dummy_field", ["bool", "filter", "range"]),
+            ("dummy_field_2", ["bool", "must", 0, "range"]),
+            ("dummy_field_3", ["bool", "must", 2, "range"])
+            ]
+        self.assertEqual(multiple_nested_range_query_result, multiple_nested_range_query_expected)
+
+        with self.assertRaises(exceptions.SystemSetupError) as ctx:
+            empty_result = processor.extract_fields_and_paths({"body":{"contents":["not_a_valid_query"]}})
+            self.assertEqual("Cannot extract range query fields from these params, missing params[\"body\"][\"query\"]",
+                         ctx.exception.args[0])
+
+    def test_get_randomized_values(self):
+        helper = self.StandardValueHelper()
+
+        for rf, expected_values_dict in zip([1.0, 0.0], [helper.saved_values, helper.new_values]):
+            # first test where we always draw a saved value, not a new random one
+            # next test where we always draw a new random value. We've made them distinct, to be able to tell which codepath is taken
+            cfg = config.Config()
+            cfg.add(config.Scope.application, "workload", "randomization.rf", rf)
+            processor = loader.QueryRandomizerWorkloadProcessor(cfg)
+            self.assertAlmostEqual(processor.rf, rf)
+
+            # Test resulting params for operation 1
+            workload = helper.get_simple_workload()
+            modified_params = processor.get_randomized_values(workload, helper.op_1_query, op_name=helper.op_name_1,
+                                                            get_standard_value=helper.get_standard_value,
+                                                            get_standard_value_source=helper.get_standard_value_source)
+            modified_range_1 = modified_params["body"]["query"]["bool"]["filter"]["range"][helper.field_name_1]
+            modified_range_2 = modified_params["body"]["query"]["bool"]["filter"]["must"][0]["range"][helper.field_name_2]
+            self.assertEqual(modified_range_1["lt"], expected_values_dict[helper.op_name_1][helper.field_name_1]["lte"]) # Note it should keep whichever of lt/lte it found in the original query
+            self.assertEqual(modified_range_1["gte"], expected_values_dict[helper.op_name_1][helper.field_name_1]["gte"])
+
+            self.assertEqual(modified_range_2["lte"], expected_values_dict[helper.op_name_1][helper.field_name_2]["lte"])
+            self.assertEqual(modified_range_2["gte"], expected_values_dict[helper.op_name_1][helper.field_name_2]["gte"])
+            self.assertEqual(modified_range_2["format"], expected_values_dict[helper.op_name_1][helper.field_name_2]["format"])
+
+            self.assertEqual(modified_params["index"], helper.index_name)
+
+            # Test resulting params for operation 2
+            workload = helper.get_simple_workload()
+            modified_params = processor.get_randomized_values(workload, helper.op_2_query, op_name=helper.op_name_2,
+                                                            get_standard_value=helper.get_standard_value,
+                                                            get_standard_value_source=helper.get_standard_value_source)
+            modified_range_1 = modified_params["body"]["query"]["range"][helper.field_name_1]
+
+            self.assertEqual(modified_range_1["lt"], expected_values_dict[helper.op_name_2][helper.field_name_1]["lte"])
+            self.assertEqual(modified_range_1["gte"], expected_values_dict[helper.op_name_2][helper.field_name_1]["gte"])
+            self.assertEqual(modified_params["index"], helper.index_name)
+
+
+    def test_on_after_load_workload(self):
+        cfg = config.Config()
+        processor = loader.QueryRandomizerWorkloadProcessor(cfg)
+        # Do nothing with default config as randomization.enabled is false
+        helper = self.StandardValueHelper()
+        input_workload = helper.get_simple_workload()
+        self.assertEqual(repr(input_workload), repr(processor.on_after_load_workload(input_workload, get_standard_value=helper.get_standard_value,
+                                                            get_standard_value_source=helper.get_standard_value_source)))
+        # It seems that comparing the workloads directly will incorrectly call them equal, even if they have differences,
+        # so compare their string representations instead
+
+        cfg = config.Config()
+        cfg.add(config.Scope.application, "workload", "randomization.enabled", True)
+        processor = loader.QueryRandomizerWorkloadProcessor(cfg)
+        self.assertEqual(processor.randomization_enabled, True)
+        self.assertEqual(processor.N, loader.QueryRandomizerWorkloadProcessor.DEFAULT_N)
+        self.assertEqual(type(processor.N), int)
+        self.assertEqual(processor.rf, loader.QueryRandomizerWorkloadProcessor.DEFAULT_RF)
+        self.assertEqual(type(processor.rf), float)
+        input_workload = helper.get_simple_workload()
+        self.assertNotEqual(repr(input_workload), repr(processor.on_after_load_workload(input_workload, get_standard_value=helper.get_standard_value,
+                                                            get_standard_value_source=helper.get_standard_value_source)))
+        for test_procedure in input_workload.test_procedures:
+            for task in test_procedure.schedule:
+                for leaf_task in task:
+                    try:
+                        op_type = workload.OperationType.from_hyphenated_string(leaf_task.operation.type)
+                    except KeyError:
+                        op_type = None
+                    if op_type == workload.OperationType.Search:
+                        self.assertIsNotNone(leaf_task.operation.param_source)
+
+
 
 # pylint: disable=too-many-public-methods
 class WorkloadSpecificationReaderTests(TestCase):
@@ -3558,6 +3847,7 @@ class WorkloadProcessorRegistryTests(TestCase):
         expected_defaults = [
             loader.TaskFilterWorkloadProcessor,
             loader.TestModeWorkloadProcessor,
+            loader.QueryRandomizerWorkloadProcessor,
             loader.DefaultWorkloadPreparator
         ]
         actual_defaults = [proc.__class__ for proc in tpr.processors]
@@ -3573,6 +3863,7 @@ class WorkloadProcessorRegistryTests(TestCase):
         expected_processors = [
             loader.TaskFilterWorkloadProcessor,
             loader.TestModeWorkloadProcessor,
+            loader.QueryRandomizerWorkloadProcessor,
             MyMockWorkloadProcessor
         ]
         actual_processors = [proc.__class__ for proc in tpr.processors]
@@ -3589,6 +3880,7 @@ class WorkloadProcessorRegistryTests(TestCase):
         expected_processors = [
             loader.TaskFilterWorkloadProcessor,
             loader.TestModeWorkloadProcessor,
+            loader.QueryRandomizerWorkloadProcessor,
             MyMockWorkloadProcessor,
             loader.DefaultWorkloadPreparator
         ]

--- a/tests/workload/loader_test.py
+++ b/tests/workload/loader_test.py
@@ -1801,12 +1801,14 @@ class WorkloadRandomizationTests(TestCase):
             full_workload = reader("unittest", workload_specification, "/mappings")
             return full_workload
 
-        def get_standard_value_source(self, op_name, field_name): # Passed to the processor, to be able to find the standard value sources for all ops/fields.
+        def get_standard_value_source(self, op_name, field_name):
+            # Passed to the processor, to be able to find the standard value sources for all ops/fields.
             # The actual source functions for the op/field pairs, which in a real application
             # would be defined in the workload's workload.py and involve some randomization
             return lambda: self.new_values[op_name][field_name]
 
-        def get_standard_value(self, op_name, field_name, index): # Passed to the processor, to be able to retrive the saved standard values for all ops/fields.
+        def get_standard_value(self, op_name, field_name, index):
+            # Passed to the processor, to be able to retrive the saved standard values for all ops/fields.
             return self.saved_values[op_name][field_name]
 
     def test_range_finding_function(self):
@@ -1895,7 +1897,7 @@ class WorkloadRandomizationTests(TestCase):
         self.assertEqual(multiple_nested_range_query_result, multiple_nested_range_query_expected)
 
         with self.assertRaises(exceptions.SystemSetupError) as ctx:
-            empty_result = processor.extract_fields_and_paths({"body":{"contents":["not_a_valid_query"]}})
+            _ = processor.extract_fields_and_paths({"body":{"contents":["not_a_valid_query"]}})
             self.assertEqual("Cannot extract range query fields from these params, missing params[\"body\"][\"query\"]",
                          ctx.exception.args[0])
 
@@ -1917,7 +1919,8 @@ class WorkloadRandomizationTests(TestCase):
                                                             get_standard_value_source=helper.get_standard_value_source)
             modified_range_1 = modified_params["body"]["query"]["bool"]["filter"]["range"][helper.field_name_1]
             modified_range_2 = modified_params["body"]["query"]["bool"]["filter"]["must"][0]["range"][helper.field_name_2]
-            self.assertEqual(modified_range_1["lt"], expected_values_dict[helper.op_name_1][helper.field_name_1]["lte"]) # Note it should keep whichever of lt/lte it found in the original query
+            self.assertEqual(modified_range_1["lt"], expected_values_dict[helper.op_name_1][helper.field_name_1]["lte"])
+            # Note it should keep whichever of lt/lte it found in the original query
             self.assertEqual(modified_range_1["gte"], expected_values_dict[helper.op_name_1][helper.field_name_1]["gte"])
 
             self.assertEqual(modified_range_2["lte"], expected_values_dict[helper.op_name_1][helper.field_name_2]["lte"])
@@ -1944,7 +1947,9 @@ class WorkloadRandomizationTests(TestCase):
         # Do nothing with default config as randomization.enabled is false
         helper = self.StandardValueHelper()
         input_workload = helper.get_simple_workload()
-        self.assertEqual(repr(input_workload), repr(processor.on_after_load_workload(input_workload, get_standard_value=helper.get_standard_value,
+        self.assertEqual(
+            repr(input_workload),
+            repr(processor.on_after_load_workload(input_workload, get_standard_value=helper.get_standard_value,
                                                             get_standard_value_source=helper.get_standard_value_source)))
         # It seems that comparing the workloads directly will incorrectly call them equal, even if they have differences,
         # so compare their string representations instead
@@ -1958,7 +1963,9 @@ class WorkloadRandomizationTests(TestCase):
         self.assertEqual(processor.rf, loader.QueryRandomizerWorkloadProcessor.DEFAULT_RF)
         self.assertEqual(type(processor.rf), float)
         input_workload = helper.get_simple_workload()
-        self.assertNotEqual(repr(input_workload), repr(processor.on_after_load_workload(input_workload, get_standard_value=helper.get_standard_value,
+        self.assertNotEqual(
+            repr(input_workload),
+            repr(processor.on_after_load_workload(input_workload, get_standard_value=helper.get_standard_value,
                                                             get_standard_value_source=helper.get_standard_value_source)))
         for test_procedure in input_workload.test_procedures:
             for task in test_procedure.schedule:

--- a/tests/workload/loader_test.py
+++ b/tests/workload/loader_test.py
@@ -1897,8 +1897,11 @@ class WorkloadRandomizationTests(TestCase):
         self.assertEqual(multiple_nested_range_query_result, multiple_nested_range_query_expected)
 
         with self.assertRaises(exceptions.SystemSetupError) as ctx:
-            _ = processor.extract_fields_and_paths({"body":{"contents":["not_a_valid_query"]}})
-            self.assertEqual("Cannot extract range query fields from these params, missing params[\"body\"][\"query\"]",
+            params = {"body":{"contents":["not_a_valid_query"]}}
+            _ = processor.extract_fields_and_paths(params)
+            self.assertEqual(
+                f"Cannot extract range query fields from these params: {params}\n, missing params[\"body\"][\"query\"]\n"
+                f"Make sure the operation in operations/default.json is well-formed",
                          ctx.exception.args[0])
 
     def test_get_randomized_values(self):
@@ -1908,7 +1911,7 @@ class WorkloadRandomizationTests(TestCase):
             # first test where we always draw a saved value, not a new random one
             # next test where we always draw a new random value. We've made them distinct, to be able to tell which codepath is taken
             cfg = config.Config()
-            cfg.add(config.Scope.application, "workload", "randomization.rf", rf)
+            cfg.add(config.Scope.application, "workload", "randomization.repeat_frequency", rf)
             processor = loader.QueryRandomizerWorkloadProcessor(cfg)
             self.assertAlmostEqual(processor.rf, rf)
 

--- a/tests/workload/params_test.py
+++ b/tests/workload/params_test.py
@@ -1407,7 +1407,8 @@ class StandardValueSourceRegistrationTests(TestCase):
         return lambda : {"gte":gte, "lte":lte}
 
     def test_register_standard_value_source(self):
-        # Test the sequence: register standard value source -> generate saved standard values -> retrieve those values or generate new values from source
+        # Test the sequence: register standard value source -> generate saved standard values
+        # -> retrieve those values or generate new values from source
         op_name = "op-1"
         field_name_1 = "field-1"
         field_name_2 = "field-2"
@@ -1425,25 +1426,32 @@ class StandardValueSourceRegistrationTests(TestCase):
         self.assertEqual(params.get_standard_value_source(op_name, field_name_1)(), {"gte":gte_field_1, "lte":lte_field_1})
 
         with self.assertRaises(exceptions.SystemSetupError) as ctx:
-            nonexistent_source = params.get_standard_value_source(op_name, field_name_2)
-            self.assertEqual("Could not find standard value source for operation {}, field {}! Make sure this is registered in workload.py".format(op_name, field_name_2), ctx.exception.args[0])
+            _ = params.get_standard_value_source(op_name, field_name_2)
+            self.assertEqual(
+                "Could not find standard value source for operation {}, field {}! Make sure this is registered in workload.py"
+                .format(op_name, field_name_2), ctx.exception.args[0])
 
         with self.assertRaises(exceptions.SystemSetupError) as ctx:
-            standard_value = params.get_standard_value(op_name, field_name_1, 0)
+            _ = params.get_standard_value(op_name, field_name_1, 0)
             self.assertEqual("No standard values generated for operation {}, field {}".format(op_name, field_name_1), ctx.exception.args[0])
 
         params.generate_standard_values_if_absent(op_name, field_name_1, n)
         self.assertEqual(params.get_standard_value(op_name, field_name_1, 0), {"gte":gte_field_1, "lte":lte_field_1})
 
-        # check that running generate_standard_values_if_absent on the same inputs does nothing - we can do this by telling it to generate 2*n, but it won't because values are already present
+        # check that running generate_standard_values_if_absent on the same inputs does nothing
+        # we can do this by telling it to generate 2*n, but it won't because values are already present
         params.generate_standard_values_if_absent(op_name, field_name_1, 2*n)
         with self.assertRaises(exceptions.SystemSetupError) as ctx:
-            standard_value = params.get_standard_value(op_name, field_name_1, n + 1)
-            self.assertEqual("Standard value index {} out of range for operation {}, field name {} ({} values total)".format(n+1, op_name, field_name_1, n), ctx.exception.args[0])
+            _ = params.get_standard_value(op_name, field_name_1, n + 1)
+            self.assertEqual(
+                "Standard value index {} out of range for operation {}, field name {} ({} values total)"
+                .format(n+1, op_name, field_name_1, n), ctx.exception.args[0])
 
         with self.assertRaises(exceptions.SystemSetupError) as ctx:
             params.generate_standard_values_if_absent(op_name, field_name_2, n)
-            self.assertEqual("Cannot generate standard values for operation {}, field {}. Standard value source is missing".format(op_name, field_name_2), ctx.exception.args[0])
+            self.assertEqual(
+                "Cannot generate standard values for operation {}, field {}. Standard value source is missing"
+                .format(op_name, field_name_2), ctx.exception.args[0])
 
         params.register_standard_value_source(op_name, field_name_2, self.get_mock_standard_value_source(gte_field_2, lte_field_2))
         self.assertEqual(params.get_standard_value_source(op_name, field_name_2)(), {"gte":gte_field_2, "lte":lte_field_2})

--- a/tests/workload/params_test.py
+++ b/tests/workload/params_test.py
@@ -1402,6 +1402,54 @@ class ParamsRegistrationTests(TestCase):
                                     "Parameter source \\[test param source\\] must be either a function or a class\\."):
             params.register_param_source_for_name(source_name, ParamsRegistrationTests.ParamSourceClass())
 
+class StandardValueSourceRegistrationTests(TestCase):
+    def get_mock_standard_value_source(self, gte, lte):
+        return lambda : {"gte":gte, "lte":lte}
+
+    def test_register_standard_value_source(self):
+        # Test the sequence: register standard value source -> generate saved standard values -> retrieve those values or generate new values from source
+        op_name = "op-1"
+        field_name_1 = "field-1"
+        field_name_2 = "field-2"
+        n = 100
+
+        gte_field_1 = 0
+        lte_field_1 = 1
+        gte_field_2 = 2
+        lte_field_2 = 3
+
+        params._clear_standard_values()
+
+        params.register_standard_value_source(op_name, field_name_1, self.get_mock_standard_value_source(gte_field_1, lte_field_1))
+
+        self.assertEqual(params.get_standard_value_source(op_name, field_name_1)(), {"gte":gte_field_1, "lte":lte_field_1})
+
+        with self.assertRaises(exceptions.SystemSetupError) as ctx:
+            nonexistent_source = params.get_standard_value_source(op_name, field_name_2)
+            self.assertEqual("Could not find standard value source for operation {}, field {}! Make sure this is registered in workload.py".format(op_name, field_name_2), ctx.exception.args[0])
+
+        with self.assertRaises(exceptions.SystemSetupError) as ctx:
+            standard_value = params.get_standard_value(op_name, field_name_1, 0)
+            self.assertEqual("No standard values generated for operation {}, field {}".format(op_name, field_name_1), ctx.exception.args[0])
+
+        params.generate_standard_values_if_absent(op_name, field_name_1, n)
+        self.assertEqual(params.get_standard_value(op_name, field_name_1, 0), {"gte":gte_field_1, "lte":lte_field_1})
+
+        # check that running generate_standard_values_if_absent on the same inputs does nothing - we can do this by telling it to generate 2*n, but it won't because values are already present
+        params.generate_standard_values_if_absent(op_name, field_name_1, 2*n)
+        with self.assertRaises(exceptions.SystemSetupError) as ctx:
+            standard_value = params.get_standard_value(op_name, field_name_1, n + 1)
+            self.assertEqual("Standard value index {} out of range for operation {}, field name {} ({} values total)".format(n+1, op_name, field_name_1, n), ctx.exception.args[0])
+
+        with self.assertRaises(exceptions.SystemSetupError) as ctx:
+            params.generate_standard_values_if_absent(op_name, field_name_2, n)
+            self.assertEqual("Cannot generate standard values for operation {}, field {}. Standard value source is missing".format(op_name, field_name_2), ctx.exception.args[0])
+
+        params.register_standard_value_source(op_name, field_name_2, self.get_mock_standard_value_source(gte_field_2, lte_field_2))
+        self.assertEqual(params.get_standard_value_source(op_name, field_name_2)(), {"gte":gte_field_2, "lte":lte_field_2})
+        self.assertEqual(params.get_standard_value_source(op_name, field_name_1)(), {"gte":gte_field_1, "lte":lte_field_1})
+
+        params._clear_standard_values()
 
 class SleepParamSourceTests(TestCase):
     def test_missing_duration_parameter(self):


### PR DESCRIPTION
### Description
Allows the user to randomize the values in range queries in a controllable way. This allows reasonable tests of cache performance, where we can't use the same query repeatedly. 

To use this, in your workload's workload.py file, you must register a "standard value source" function in the register() function. This is done on an operation and field level. For example, in nyc_taxis, say you wanted to randomize the field "trip_distance" in the operation "distance_amount_agg". Your workload.py would look like: 

```
def trip_distance_std_value_source():
    gte = random.randrange(1, 7)
    lte = random.randrange(gte, 15)
    return {"gte":gte, "lte":lte}

def register(registry):
    registry.register_runner("delete-snapshot", delete_snapshot, async_runner=True)
    registry.register_standard_value_source("distance_amount_agg", "trip_distance", trip_distance_std_value_source)

```

Then, to enable randomization when you run the workload, you supply the flag `--randomization-enabled`. To control the fraction of queries which may be repeated (for example, to mimic a cache hit), you supply the flag `--randomization-rf 0.3`, which would mean the "repeat frequency" for this workload is 0.3 = 30%. If `--randomization-enabled` isn't passed, there is no change from the user's perspective and you don't have to register standard value sources. 

This works by adding a new WorkloadProcessor called QueryRandomizerWorkloadProcessor. If randomization is enabled, its on_after_load_workload() function will walk through the default workload schedule (the one specified in test_procedures/default.json). For all search operations, it will see if a standard value source was registered for that operation and field type. Then it gives the operation a new ParamSource. 

This ParamSource is a lambda supplied by the processor. When it's run, it finds the range section of the query, and replaces its gte/lte (and format, if present) values with the ones provided by the standard value source for that operation and field. 

To allow a controllable fraction of "cache hits", we use the rf parameter from above. 

If rf = 0.3, then 30% of the time, we want a repeated value. To achieve this, we generate and save some number N of standard values for each op/field pair at the beginning of the workload, using the same standard value source function. (Default = 5000, this is configurable via `--randomization-n`). We pick one of these saved values to return from the lambda. (We draw the index of this value from the Zipf distribution on N items, which empirically matches the distribution for online cache requests, and has some other advantages too). As the workload goes on, indices will be drawn multiple times, so the query values will repeat. 

The other 70% of the time, we generate a totally new value from the standard value source function, which will not have been seen before (a "cache miss"). 

### Issues Resolved
Resolves https://github.com/opensearch-project/opensearch-benchmark/issues/443

### Testing
- [x] New functionality includes testing

Added UTs testing various components of the workflow. Also tested manually with several different workloads while watching the parameters, to make sure they were changing correctly and the fraction of ones being drawn randomly was correct. Finally, re-ran a cache-related workload that we had run before with a previous, non-generic way of randomizing queries, and made sure the number of hits, misses, evictions, etc matched what we observed then. 

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
